### PR TITLE
Generic link/button DSL across all blocks + Pay Now CTA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`LinkStyle` enum** on `InvoiceElement.Link` — `TEXT` (default, inline primary-colored Material 3 `labelLarge`) or `BUTTON` (styled CTA — filled primary container, white label, 20dp pill, M3 `Button`-equivalent).
+- **`button(text, href)`** in the shared `ContentBuilder` DSL, available wherever rich content is accepted: `custom("…") { … }`, `paymentInfo { notes { … } }`, `footer { notes/terms/customContent { … } }`.
+- **`link()` callable in any rich-content block.** Previously only `Custom` sections supported `link()`; now `Footer.notes/terms/customContent` and `PaymentInfo.notes` accept the same content lambda.
+- **`paymentInfo { paymentLink(text, href, style?) }`** overload — custom display text and explicit `LinkStyle`.
+- **`paymentInfo { paymentButton(text, href) }`** convenience — equivalent to `paymentLink(text, href, LinkStyle.BUTTON)`.
+- HTML email renders BUTTON-style links as bulletproof `<table>`-wrapped buttons (Outlook-friendly).
+- `payButton` test fixture exercising BUTTON style and inline links in notes/footer.
 - **Sealed IR** with 9 invoice section types: Header, BillFrom, BillTo, LineItems, Summary, PaymentInfo, Footer, Custom, MetaBlock
 - **Type-safe DSL** builder: `invoice { header { ... } lineItems { ... } summary { ... } }`
 - **Compose renderer** (`render-compose`): `InvoiceView` and `InvoiceContent` composables for interactive preview
@@ -28,3 +35,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Validation**: required field checks with descriptive error messages
 - **Email safety**: validated output (no scripts, iframes, or unsafe elements)
 - **Dokka API documentation** generation
+
+### Changed
+
+- **BREAKING (IR):** `InvoiceSection.PaymentInfo.paymentLink: String?` → `InvoiceElement.Link?`. The DSL `paymentLink(href: String)` is unchanged; the underlying field type is the breaking change for code that destructures the IR directly.
+- **BREAKING (IR):** `InvoiceSection.PaymentInfo.notes: String?` → `List<InvoiceElement>?`. The DSL `notes("…")` form is unchanged; the field type is the breaking change.
+- **BREAKING (IR):** `InvoiceSection.Footer.notes/terms/customContent: String?` → `List<InvoiceElement>?`. DSL string-form setters are unchanged.
+- **BREAKING (DSL minor):** `CustomBuilder.row(vararg weights: Float, init: ContentBuilder.() -> Unit)` — receiver narrowed from `CustomBuilder` to `ContentBuilder`. Inside a `row { }` block you now have only content primitives; you cannot reference the section `key`. No bundled fixture used the old broader receiver.
+- Pay link rendering no longer hard-prefixes `"Pay Online: "` — the rendered text is the link's `text` field (default `"Pay Now"` when omitted).
+
+### Removed
+
+- `PdfRendererTest.paymentLinkAnnotationPresent` — misleading text-substring check; real PDF annotation coverage lives in `fidelity-test`'s `LinkAndImageTest`.

--- a/README.md
+++ b/README.md
@@ -323,15 +323,33 @@ lineItems {
 
 ### Payment info
 
+The pay link can render as an inline text link (default) or as a styled "Pay Now" CTA button.
+Both are clickable across PDF, HTML email, and Compose.
+
 ```kotlin
 paymentInfo {
     bankName("First National Bank")
     accountNumber("1234567890")
     routingNumber("021000021")
+
+    // Default: text link, label "Pay Now"
     paymentLink("https://pay.example.com/inv-001")
-    notes("Wire transfer preferred for amounts over $1,000")
+
+    // Or a custom-labelled text link:
+    // paymentLink("Pay this invoice", "https://pay.example.com/inv-001")
+
+    // Or a styled CTA button (Material 3 FilledButton-equivalent):
+    // paymentButton("Pay $1,000 Now", "https://pay.example.com/inv-001")
+
+    notes {
+        text("Wire transfer alternative — see ")
+        link("transfer policy", "https://example.com/wire-policy")
+    }
 }
 ```
+
+`link()` and `button()` are also available inside `footer { notes { ... } }` /
+`terms { ... }` / `customContent { ... }` and inside any `custom("...") { ... }` block.
 
 ### Metadata blocks
 

--- a/core/src/commonMain/kotlin/com/chrisjenx/kinvoicing/InvoiceElement.kt
+++ b/core/src/commonMain/kotlin/com/chrisjenx/kinvoicing/InvoiceElement.kt
@@ -1,6 +1,17 @@
 package com.chrisjenx.kinvoicing
 
 /**
+ * Visual style hint for [InvoiceElement.Link].
+ * Renderers map TEXT to inline hyperlink typography and BUTTON to a filled CTA.
+ */
+public enum class LinkStyle {
+    /** Inline text hyperlink — primary color, M3 labelLarge weight. */
+    TEXT,
+    /** Filled CTA button — primary container, white label, M3 FilledButton-equivalent. */
+    BUTTON,
+}
+
+/**
  * Low-level building blocks for [InvoiceSection.Custom] sections.
  * Renderers map each variant to platform-specific UI primitives.
  */
@@ -28,8 +39,13 @@ public sealed class InvoiceElement {
      * Hyperlink with display text.
      * @property text The visible label (e.g., "Visit Our Site").
      * @property href The link URL (e.g., "https://example.com").
+     * @property style Visual style — defaults to [LinkStyle.TEXT] (inline text link).
      */
-    public data class Link(val text: String, val href: String) : InvoiceElement()
+    public data class Link(
+        val text: String,
+        val href: String,
+        val style: LinkStyle = LinkStyle.TEXT,
+    ) : InvoiceElement()
 
     /**
      * Inline image from an [ImageSource].

--- a/core/src/commonMain/kotlin/com/chrisjenx/kinvoicing/InvoiceFixtures.kt
+++ b/core/src/commonMain/kotlin/com/chrisjenx/kinvoicing/InvoiceFixtures.kt
@@ -88,7 +88,7 @@ public object InvoiceFixtures {
 
     /** All fixtures for parameterized testing. */
     public val all: List<InvoiceDocument> by lazy {
-        listOf(basic, fullFeatured, negativeValues, long, minimal, styled, linksAndImages, paidBadge, voidWatermark)
+        listOf(basic, fullFeatured, negativeValues, long, minimal, styled, linksAndImages, paidBadge, voidWatermark, payButton)
     }
 
     /** Single brand, 3 line items, no sub-items, no discounts. */
@@ -394,6 +394,45 @@ public object InvoiceFixtures {
         }
         footer {
             notes("Links and images test fixture.")
+        }
+    }
+
+    /** Pay-button + rich-notes fixture exercising BUTTON style and inline links in notes/footer. */
+    public val payButton: InvoiceDocument = invoice {
+        header {
+            invoiceNumber("INV-2026-PAYBTN")
+            issueDate(LocalDate(2026, 5, 1))
+            branding {
+                primary { name("Acme Inc."); website("https://acme.com") }
+            }
+        }
+        billTo {
+            name("Test Customer")
+            address("100 Demo St", "Sample City, ZZ 99999")
+        }
+        lineItems {
+            columns("Description", "Amount")
+            item("Consulting", amount = 1000.0)
+        }
+        summary {
+            currency("USD")
+        }
+        paymentInfo {
+            bankName("First National")
+            paymentButton("Pay $1,000 Now", "https://pay.acme.com/inv-paybtn")
+            notes {
+                text("Wire transfer alternative — see ")
+                link("transfer policy", "https://acme.com/wire-policy")
+            }
+        }
+        footer {
+            notes {
+                text("Thanks for your business! Read our ")
+                link("terms", "https://acme.com/terms")
+                text(" or ")
+                link("contact support", "mailto:billing@acme.com")
+                text(".")
+            }
         }
     }
 }

--- a/core/src/commonMain/kotlin/com/chrisjenx/kinvoicing/InvoiceSection.kt
+++ b/core/src/commonMain/kotlin/com/chrisjenx/kinvoicing/InvoiceSection.kt
@@ -45,17 +45,17 @@ public sealed class InvoiceSection {
         val bankName: String? = null,
         val accountNumber: String? = null,
         val routingNumber: String? = null,
-        val paymentLink: String? = null,
+        val paymentLink: InvoiceElement.Link? = null,
         /** Raw data to encode as a QR code (e.g., a payment URL). */
         val qrCodeData: String? = null,
-        val notes: String? = null,
+        val notes: List<InvoiceElement>? = null,
     ) : InvoiceSection()
 
     /** Closing notes, terms and conditions, or free-form content. */
     public data class Footer(
-        val notes: String? = null,
-        val terms: String? = null,
-        val customContent: String? = null,
+        val notes: List<InvoiceElement>? = null,
+        val terms: List<InvoiceElement>? = null,
+        val customContent: List<InvoiceElement>? = null,
     ) : InvoiceSection()
 
     /**

--- a/core/src/commonMain/kotlin/com/chrisjenx/kinvoicing/builders/ContentBuilder.kt
+++ b/core/src/commonMain/kotlin/com/chrisjenx/kinvoicing/builders/ContentBuilder.kt
@@ -20,7 +20,7 @@ import com.chrisjenx.kinvoicing.util.requireSafeUrl
  * ```
  */
 @InvoiceDsl
-public class ContentBuilder {
+public open class ContentBuilder {
     private val elements: MutableList<InvoiceElement> = mutableListOf()
 
     /** Add a text element, optionally referencing a renderer-defined style via [styleRef]. */
@@ -74,7 +74,4 @@ public class ContentBuilder {
     }
 
     internal fun build(): List<InvoiceElement> = elements.toList()
-
-    /** Test-only accessor — kept `internal` to avoid widening the public surface. */
-    internal fun buildPublic(): List<InvoiceElement> = build()
 }

--- a/core/src/commonMain/kotlin/com/chrisjenx/kinvoicing/builders/ContentBuilder.kt
+++ b/core/src/commonMain/kotlin/com/chrisjenx/kinvoicing/builders/ContentBuilder.kt
@@ -1,0 +1,80 @@
+package com.chrisjenx.kinvoicing.builders
+
+import com.chrisjenx.kinvoicing.ImageSource
+import com.chrisjenx.kinvoicing.InvoiceDsl
+import com.chrisjenx.kinvoicing.InvoiceElement
+import com.chrisjenx.kinvoicing.LinkStyle
+import com.chrisjenx.kinvoicing.util.requireSafeUrl
+
+/**
+ * Shared inline-content DSL used by every block that holds a list of [InvoiceElement]s
+ * (Custom sections, Footer notes/terms/customContent, PaymentInfo notes).
+ *
+ * ```kotlin
+ * notes {
+ *     text("Read our ")
+ *     link("terms", "https://acme.com/terms")
+ *     text(" or ")
+ *     button("Pay Now", "https://pay.acme.com")
+ * }
+ * ```
+ */
+@InvoiceDsl
+public class ContentBuilder {
+    private val elements: MutableList<InvoiceElement> = mutableListOf()
+
+    /** Add a text element, optionally referencing a renderer-defined style via [styleRef]. */
+    public fun text(value: String, styleRef: String? = null) {
+        elements.add(InvoiceElement.Text(value, styleRef))
+    }
+
+    /** Add an inline TEXT-style hyperlink. Renders as primary-colored M3 labelLarge text. */
+    public fun link(text: String, href: String) {
+        elements.add(InvoiceElement.Link(text, requireSafeUrl(href, "href"), LinkStyle.TEXT))
+    }
+
+    /** Add a BUTTON-style CTA. Renders as M3 FilledButton-equivalent with primary container. */
+    public fun button(text: String, href: String) {
+        elements.add(InvoiceElement.Link(text, requireSafeUrl(href, "href"), LinkStyle.BUTTON))
+    }
+
+    /** Add vertical whitespace of the given [height]. */
+    public fun spacer(height: Int = 16) {
+        elements.add(InvoiceElement.Spacer(height))
+    }
+
+    /** Add a horizontal divider line. */
+    public fun divider() {
+        elements.add(InvoiceElement.Divider)
+    }
+
+    /** Add an inline image from raw bytes. */
+    public fun image(
+        data: ByteArray,
+        contentType: String = "image/png",
+        width: Int? = null,
+        height: Int? = null,
+    ) {
+        elements.add(InvoiceElement.Image(ImageSource.Bytes(data, contentType), width, height))
+    }
+
+    /** Add an inline image from an [ImageSource]. */
+    public fun image(
+        source: ImageSource,
+        width: Int? = null,
+        height: Int? = null,
+    ) {
+        elements.add(InvoiceElement.Image(source, width, height))
+    }
+
+    /** Add a horizontal row of child elements. [weights] controls relative column widths. */
+    public fun row(vararg weights: Float, init: ContentBuilder.() -> Unit) {
+        val children = ContentBuilder().apply(init).build()
+        elements.add(InvoiceElement.Row(children, weights.toList()))
+    }
+
+    internal fun build(): List<InvoiceElement> = elements.toList()
+
+    /** Test-only accessor — kept `internal` to avoid widening the public surface. */
+    internal fun buildPublic(): List<InvoiceElement> = build()
+}

--- a/core/src/commonMain/kotlin/com/chrisjenx/kinvoicing/builders/CustomBuilder.kt
+++ b/core/src/commonMain/kotlin/com/chrisjenx/kinvoicing/builders/CustomBuilder.kt
@@ -1,45 +1,38 @@
 package com.chrisjenx.kinvoicing.builders
 
-import com.chrisjenx.kinvoicing.*
-import com.chrisjenx.kinvoicing.util.requireSafeUrl
+import com.chrisjenx.kinvoicing.ImageSource
+import com.chrisjenx.kinvoicing.InvoiceDsl
+import com.chrisjenx.kinvoicing.InvoiceSection
 
 /**
- * DSL builder for [InvoiceSection.Custom] sections composed of [InvoiceElement] primitives.
+ * DSL builder for [InvoiceSection.Custom] sections composed of inline content elements.
  *
  * ```kotlin
  * custom("terms-banner") {
  *     text("Special terms apply", styleRef = "bold")
  *     divider()
- *     row(1f, 1f) {
- *         text("Left column")
- *         text("Right column")
- *     }
+ *     link("Read more", "https://example.com/terms")
  * }
  * ```
  */
 @InvoiceDsl
 public class CustomBuilder(private val key: String) {
-    private val elements: MutableList<InvoiceElement> = mutableListOf()
+    private val content: ContentBuilder = ContentBuilder()
 
     /** Add a text element, optionally referencing a renderer-defined style via [styleRef]. */
-    public fun text(value: String, styleRef: String? = null) {
-        elements.add(InvoiceElement.Text(value, styleRef))
-    }
+    public fun text(value: String, styleRef: String? = null): Unit = content.text(value, styleRef)
 
     /** Add vertical whitespace of the given [height]. */
-    public fun spacer(height: Int = 16) {
-        elements.add(InvoiceElement.Spacer(height))
-    }
+    public fun spacer(height: Int = 16): Unit = content.spacer(height)
 
     /** Add a horizontal divider line. */
-    public fun divider() {
-        elements.add(InvoiceElement.Divider)
-    }
+    public fun divider(): Unit = content.divider()
 
-    /** Add a hyperlink with display [text] pointing to [href]. */
-    public fun link(text: String, href: String) {
-        elements.add(InvoiceElement.Link(text, requireSafeUrl(href, "href")))
-    }
+    /** Add an inline TEXT-style hyperlink with display [text] pointing to [href]. */
+    public fun link(text: String, href: String): Unit = content.link(text, href)
+
+    /** Add a BUTTON-style CTA with display [text] pointing to [href]. */
+    public fun button(text: String, href: String): Unit = content.button(text, href)
 
     /** Add an inline image from raw bytes. */
     public fun image(
@@ -47,27 +40,18 @@ public class CustomBuilder(private val key: String) {
         contentType: String = "image/png",
         width: Int? = null,
         height: Int? = null,
-    ) {
-        elements.add(InvoiceElement.Image(ImageSource.Bytes(data, contentType), width, height))
-    }
+    ): Unit = content.image(data, contentType, width, height)
 
     /** Add an inline image from an [ImageSource]. */
-    public fun image(
-        source: ImageSource,
-        width: Int? = null,
-        height: Int? = null,
-    ) {
-        elements.add(InvoiceElement.Image(source, width, height))
-    }
+    public fun image(source: ImageSource, width: Int? = null, height: Int? = null): Unit =
+        content.image(source, width, height)
 
     /** Add a horizontal row of child elements. [weights] controls relative column widths. */
-    public fun row(vararg weights: Float, init: CustomBuilder.() -> Unit) {
-        val children = CustomBuilder(key).apply(init).elements.toList()
-        elements.add(InvoiceElement.Row(children, weights.toList()))
-    }
+    public fun row(vararg weights: Float, init: ContentBuilder.() -> Unit): Unit =
+        content.row(*weights, init = init)
 
     internal fun build(): InvoiceSection.Custom = InvoiceSection.Custom(
         key = key,
-        content = elements.toList(),
+        content = content.build(),
     )
 }

--- a/core/src/commonMain/kotlin/com/chrisjenx/kinvoicing/builders/CustomBuilder.kt
+++ b/core/src/commonMain/kotlin/com/chrisjenx/kinvoicing/builders/CustomBuilder.kt
@@ -1,11 +1,13 @@
 package com.chrisjenx.kinvoicing.builders
 
-import com.chrisjenx.kinvoicing.ImageSource
 import com.chrisjenx.kinvoicing.InvoiceDsl
 import com.chrisjenx.kinvoicing.InvoiceSection
 
 /**
  * DSL builder for [InvoiceSection.Custom] sections composed of inline content elements.
+ *
+ * Inherits the full [ContentBuilder] surface — `text()`, `link()`, `button()`, `spacer()`,
+ * `divider()`, `image()`, `row()`.
  *
  * ```kotlin
  * custom("terms-banner") {
@@ -16,42 +18,9 @@ import com.chrisjenx.kinvoicing.InvoiceSection
  * ```
  */
 @InvoiceDsl
-public class CustomBuilder(private val key: String) {
-    private val content: ContentBuilder = ContentBuilder()
-
-    /** Add a text element, optionally referencing a renderer-defined style via [styleRef]. */
-    public fun text(value: String, styleRef: String? = null): Unit = content.text(value, styleRef)
-
-    /** Add vertical whitespace of the given [height]. */
-    public fun spacer(height: Int = 16): Unit = content.spacer(height)
-
-    /** Add a horizontal divider line. */
-    public fun divider(): Unit = content.divider()
-
-    /** Add an inline TEXT-style hyperlink with display [text] pointing to [href]. */
-    public fun link(text: String, href: String): Unit = content.link(text, href)
-
-    /** Add a BUTTON-style CTA with display [text] pointing to [href]. */
-    public fun button(text: String, href: String): Unit = content.button(text, href)
-
-    /** Add an inline image from raw bytes. */
-    public fun image(
-        data: ByteArray,
-        contentType: String = "image/png",
-        width: Int? = null,
-        height: Int? = null,
-    ): Unit = content.image(data, contentType, width, height)
-
-    /** Add an inline image from an [ImageSource]. */
-    public fun image(source: ImageSource, width: Int? = null, height: Int? = null): Unit =
-        content.image(source, width, height)
-
-    /** Add a horizontal row of child elements. [weights] controls relative column widths. */
-    public fun row(vararg weights: Float, init: ContentBuilder.() -> Unit): Unit =
-        content.row(*weights, init = init)
-
-    internal fun build(): InvoiceSection.Custom = InvoiceSection.Custom(
+public class CustomBuilder(private val key: String) : ContentBuilder() {
+    internal fun buildSection(): InvoiceSection.Custom = InvoiceSection.Custom(
         key = key,
-        content = content.build(),
+        content = build(),
     )
 }

--- a/core/src/commonMain/kotlin/com/chrisjenx/kinvoicing/builders/FooterBuilder.kt
+++ b/core/src/commonMain/kotlin/com/chrisjenx/kinvoicing/builders/FooterBuilder.kt
@@ -12,32 +12,32 @@ public class FooterBuilder {
     private var customContent: List<InvoiceElement>? = null
 
     /** Set closing notes from a single plain-text string. */
-    public fun notes(value: String) { notes = listOf(InvoiceElement.Text(value)) }
+    public fun notes(value: String) { notes = plain(value) }
 
     /** Set rich closing notes — supports text(), link(), button(), etc. */
-    public fun notes(init: ContentBuilder.() -> Unit) {
-        notes = ContentBuilder().apply(init).build()
-    }
+    public fun notes(init: ContentBuilder.() -> Unit) { notes = rich(init) }
 
     /** Set payment terms from a single plain-text string. */
-    public fun terms(value: String) { terms = listOf(InvoiceElement.Text(value)) }
+    public fun terms(value: String) { terms = plain(value) }
 
     /** Set rich payment terms — supports text(), link(), button(), etc. */
-    public fun terms(init: ContentBuilder.() -> Unit) {
-        terms = ContentBuilder().apply(init).build()
-    }
+    public fun terms(init: ContentBuilder.() -> Unit) { terms = rich(init) }
 
     /** Set arbitrary custom content from a single plain-text string. */
-    public fun customContent(value: String) { customContent = listOf(InvoiceElement.Text(value)) }
+    public fun customContent(value: String) { customContent = plain(value) }
 
     /** Set rich custom content — supports text(), link(), button(), etc. */
-    public fun customContent(init: ContentBuilder.() -> Unit) {
-        customContent = ContentBuilder().apply(init).build()
-    }
+    public fun customContent(init: ContentBuilder.() -> Unit) { customContent = rich(init) }
 
     internal fun build(): InvoiceSection.Footer = InvoiceSection.Footer(
         notes = notes,
         terms = terms,
         customContent = customContent,
     )
+
+    private companion object {
+        private fun plain(value: String): List<InvoiceElement> = listOf(InvoiceElement.Text(value))
+        private fun rich(init: ContentBuilder.() -> Unit): List<InvoiceElement> =
+            ContentBuilder().apply(init).build()
+    }
 }

--- a/core/src/commonMain/kotlin/com/chrisjenx/kinvoicing/builders/FooterBuilder.kt
+++ b/core/src/commonMain/kotlin/com/chrisjenx/kinvoicing/builders/FooterBuilder.kt
@@ -11,12 +11,29 @@ public class FooterBuilder {
     private var terms: List<InvoiceElement>? = null
     private var customContent: List<InvoiceElement>? = null
 
-    /** Set closing notes (e.g., "Thank you for your business!"). */
+    /** Set closing notes from a single plain-text string. */
     public fun notes(value: String) { notes = listOf(InvoiceElement.Text(value)) }
-    /** Set payment terms (e.g., "Net 30"). */
+
+    /** Set rich closing notes — supports text(), link(), button(), etc. */
+    public fun notes(init: ContentBuilder.() -> Unit) {
+        notes = ContentBuilder().apply(init).build()
+    }
+
+    /** Set payment terms from a single plain-text string. */
     public fun terms(value: String) { terms = listOf(InvoiceElement.Text(value)) }
-    /** Set arbitrary custom content rendered below notes and terms. */
+
+    /** Set rich payment terms — supports text(), link(), button(), etc. */
+    public fun terms(init: ContentBuilder.() -> Unit) {
+        terms = ContentBuilder().apply(init).build()
+    }
+
+    /** Set arbitrary custom content from a single plain-text string. */
     public fun customContent(value: String) { customContent = listOf(InvoiceElement.Text(value)) }
+
+    /** Set rich custom content — supports text(), link(), button(), etc. */
+    public fun customContent(init: ContentBuilder.() -> Unit) {
+        customContent = ContentBuilder().apply(init).build()
+    }
 
     internal fun build(): InvoiceSection.Footer = InvoiceSection.Footer(
         notes = notes,

--- a/core/src/commonMain/kotlin/com/chrisjenx/kinvoicing/builders/FooterBuilder.kt
+++ b/core/src/commonMain/kotlin/com/chrisjenx/kinvoicing/builders/FooterBuilder.kt
@@ -1,21 +1,22 @@
 package com.chrisjenx.kinvoicing.builders
 
 import com.chrisjenx.kinvoicing.InvoiceDsl
+import com.chrisjenx.kinvoicing.InvoiceElement
 import com.chrisjenx.kinvoicing.InvoiceSection
 
 /** DSL builder for the [InvoiceSection.Footer] section. */
 @InvoiceDsl
 public class FooterBuilder {
-    private var notes: String? = null
-    private var terms: String? = null
-    private var customContent: String? = null
+    private var notes: List<InvoiceElement>? = null
+    private var terms: List<InvoiceElement>? = null
+    private var customContent: List<InvoiceElement>? = null
 
     /** Set closing notes (e.g., "Thank you for your business!"). */
-    public fun notes(value: String) { notes = value }
+    public fun notes(value: String) { notes = listOf(InvoiceElement.Text(value)) }
     /** Set payment terms (e.g., "Net 30"). */
-    public fun terms(value: String) { terms = value }
+    public fun terms(value: String) { terms = listOf(InvoiceElement.Text(value)) }
     /** Set arbitrary custom content rendered below notes and terms. */
-    public fun customContent(value: String) { customContent = value }
+    public fun customContent(value: String) { customContent = listOf(InvoiceElement.Text(value)) }
 
     internal fun build(): InvoiceSection.Footer = InvoiceSection.Footer(
         notes = notes,

--- a/core/src/commonMain/kotlin/com/chrisjenx/kinvoicing/builders/InvoiceBuilder.kt
+++ b/core/src/commonMain/kotlin/com/chrisjenx/kinvoicing/builders/InvoiceBuilder.kt
@@ -89,7 +89,7 @@ public class InvoiceBuilder {
 
     /** Add a custom section identified by [key], built from [InvoiceElement] primitives. */
     public fun custom(key: String, init: CustomBuilder.() -> Unit) {
-        customSections.add(CustomBuilder(key).apply(init).build())
+        customSections.add(CustomBuilder(key).apply(init).buildSection())
     }
 
     /** Build the [InvoiceDocument], sorting sections into canonical order. */

--- a/core/src/commonMain/kotlin/com/chrisjenx/kinvoicing/builders/PaymentInfoBuilder.kt
+++ b/core/src/commonMain/kotlin/com/chrisjenx/kinvoicing/builders/PaymentInfoBuilder.kt
@@ -26,13 +26,7 @@ public class PaymentInfoBuilder {
     public fun routingNumber(value: String) { routingNumber = value }
 
     /** Set a URL where the recipient can pay online. Renders as a "Pay Now" inline TEXT link. */
-    public fun paymentLink(href: String) {
-        paymentLink = InvoiceElement.Link(
-            text = "Pay Now",
-            href = requireSafeUrl(href, "paymentLink"),
-            style = LinkStyle.TEXT,
-        )
-    }
+    public fun paymentLink(href: String): Unit = paymentLink("Pay Now", href, LinkStyle.TEXT)
 
     /** Set a payment link with custom display [text] and explicit [style]. */
     public fun paymentLink(
@@ -48,13 +42,7 @@ public class PaymentInfoBuilder {
     }
 
     /** Convenience: render the payment CTA as a styled BUTTON. */
-    public fun paymentButton(text: String, href: String) {
-        paymentLink = InvoiceElement.Link(
-            text = text,
-            href = requireSafeUrl(href, "paymentLink"),
-            style = LinkStyle.BUTTON,
-        )
-    }
+    public fun paymentButton(text: String, href: String): Unit = paymentLink(text, href, LinkStyle.BUTTON)
 
     /** Set raw data to encode as a QR code (e.g., a payment URL). */
     public fun qrCodeData(value: String) { qrCodeData = value }

--- a/core/src/commonMain/kotlin/com/chrisjenx/kinvoicing/builders/PaymentInfoBuilder.kt
+++ b/core/src/commonMain/kotlin/com/chrisjenx/kinvoicing/builders/PaymentInfoBuilder.kt
@@ -18,18 +18,56 @@ public class PaymentInfoBuilder {
 
     /** Set the bank or financial institution name. */
     public fun bankName(value: String) { bankName = value }
+
     /** Set the account number (consider masking for display, e.g., "****4242"). */
     public fun accountNumber(value: String) { accountNumber = value }
+
     /** Set the bank routing/sort code number. */
     public fun routingNumber(value: String) { routingNumber = value }
-    /** Set a URL where the recipient can pay online. Defaults to "Pay Now" inline TEXT link. */
-    public fun paymentLink(value: String) {
-        paymentLink = InvoiceElement.Link("Pay Now", requireSafeUrl(value, "paymentLink"), LinkStyle.TEXT)
+
+    /** Set a URL where the recipient can pay online. Renders as a "Pay Now" inline TEXT link. */
+    public fun paymentLink(href: String) {
+        paymentLink = InvoiceElement.Link(
+            text = "Pay Now",
+            href = requireSafeUrl(href, "paymentLink"),
+            style = LinkStyle.TEXT,
+        )
     }
+
+    /** Set a payment link with custom display [text] and explicit [style]. */
+    public fun paymentLink(
+        text: String,
+        href: String,
+        style: LinkStyle = LinkStyle.TEXT,
+    ) {
+        paymentLink = InvoiceElement.Link(
+            text = text,
+            href = requireSafeUrl(href, "paymentLink"),
+            style = style,
+        )
+    }
+
+    /** Convenience: render the payment CTA as a styled BUTTON. */
+    public fun paymentButton(text: String, href: String) {
+        paymentLink = InvoiceElement.Link(
+            text = text,
+            href = requireSafeUrl(href, "paymentLink"),
+            style = LinkStyle.BUTTON,
+        )
+    }
+
     /** Set raw data to encode as a QR code (e.g., a payment URL). */
     public fun qrCodeData(value: String) { qrCodeData = value }
-    /** Set additional payment-related notes. */
-    public fun notes(value: String) { notes = listOf(InvoiceElement.Text(value)) }
+
+    /** Set additional payment-related notes from a single string of plain text. */
+    public fun notes(value: String) {
+        notes = listOf(InvoiceElement.Text(value))
+    }
+
+    /** Set rich notes from a content lambda — supports text(), link(), button(), spacer(), etc. */
+    public fun notes(init: ContentBuilder.() -> Unit) {
+        notes = ContentBuilder().apply(init).build()
+    }
 
     internal fun build(): InvoiceSection.PaymentInfo = InvoiceSection.PaymentInfo(
         bankName = bankName,

--- a/core/src/commonMain/kotlin/com/chrisjenx/kinvoicing/builders/PaymentInfoBuilder.kt
+++ b/core/src/commonMain/kotlin/com/chrisjenx/kinvoicing/builders/PaymentInfoBuilder.kt
@@ -1,7 +1,9 @@
 package com.chrisjenx.kinvoicing.builders
 
 import com.chrisjenx.kinvoicing.InvoiceDsl
+import com.chrisjenx.kinvoicing.InvoiceElement
 import com.chrisjenx.kinvoicing.InvoiceSection
+import com.chrisjenx.kinvoicing.LinkStyle
 import com.chrisjenx.kinvoicing.util.requireSafeUrl
 
 /** DSL builder for [InvoiceSection.PaymentInfo] with bank and payment link details. */
@@ -10,9 +12,9 @@ public class PaymentInfoBuilder {
     private var bankName: String? = null
     private var accountNumber: String? = null
     private var routingNumber: String? = null
-    private var paymentLink: String? = null
+    private var paymentLink: InvoiceElement.Link? = null
     private var qrCodeData: String? = null
-    private var notes: String? = null
+    private var notes: List<InvoiceElement>? = null
 
     /** Set the bank or financial institution name. */
     public fun bankName(value: String) { bankName = value }
@@ -20,12 +22,14 @@ public class PaymentInfoBuilder {
     public fun accountNumber(value: String) { accountNumber = value }
     /** Set the bank routing/sort code number. */
     public fun routingNumber(value: String) { routingNumber = value }
-    /** Set a URL where the recipient can pay online. */
-    public fun paymentLink(value: String) { paymentLink = requireSafeUrl(value, "paymentLink") }
+    /** Set a URL where the recipient can pay online. Defaults to "Pay Now" inline TEXT link. */
+    public fun paymentLink(value: String) {
+        paymentLink = InvoiceElement.Link("Pay Now", requireSafeUrl(value, "paymentLink"), LinkStyle.TEXT)
+    }
     /** Set raw data to encode as a QR code (e.g., a payment URL). */
     public fun qrCodeData(value: String) { qrCodeData = value }
     /** Set additional payment-related notes. */
-    public fun notes(value: String) { notes = value }
+    public fun notes(value: String) { notes = listOf(InvoiceElement.Text(value)) }
 
     internal fun build(): InvoiceSection.PaymentInfo = InvoiceSection.PaymentInfo(
         bankName = bankName,

--- a/core/src/commonTest/kotlin/com/chrisjenx/kinvoicing/DslBuilderTest.kt
+++ b/core/src/commonTest/kotlin/com/chrisjenx/kinvoicing/DslBuilderTest.kt
@@ -302,7 +302,7 @@ class DslBuilderTest {
         assertEquals("First National", payment.bankName)
         assertEquals("****4242", payment.accountNumber)
         assertEquals("021000021", payment.routingNumber)
-        assertEquals("https://pay.example.com", payment.paymentLink)
+        assertEquals("https://pay.example.com", payment.paymentLink?.href)
     }
 
     @Test

--- a/core/src/commonTest/kotlin/com/chrisjenx/kinvoicing/DslBuilderTest.kt
+++ b/core/src/commonTest/kotlin/com/chrisjenx/kinvoicing/DslBuilderTest.kt
@@ -431,4 +431,60 @@ class DslBuilderTest {
             assertTrue(doc.sections.isNotEmpty(), "Fixture $i has no sections")
         }
     }
+
+    @Test
+    fun paymentInfoLinkWithCustomTextDefaultsToTextStyle() {
+        val doc = invoice {
+            paymentInfo { paymentLink("Pay this invoice", "https://pay.example.com") }
+        }
+        val pay = doc.sections.filterIsInstance<InvoiceSection.PaymentInfo>().single()
+        assertEquals("Pay this invoice", pay.paymentLink?.text)
+        assertEquals("https://pay.example.com", pay.paymentLink?.href)
+        assertEquals(LinkStyle.TEXT, pay.paymentLink?.style)
+    }
+
+    @Test
+    fun paymentInfoLinkWithExplicitButtonStyle() {
+        val doc = invoice {
+            paymentInfo { paymentLink("Pay Now", "https://pay.example.com", LinkStyle.BUTTON) }
+        }
+        val pay = doc.sections.filterIsInstance<InvoiceSection.PaymentInfo>().single()
+        assertEquals(LinkStyle.BUTTON, pay.paymentLink?.style)
+    }
+
+    @Test
+    fun paymentButtonShortcutProducesButtonStyle() {
+        val doc = invoice {
+            paymentInfo { paymentButton("Pay Now", "https://pay.example.com") }
+        }
+        val pay = doc.sections.filterIsInstance<InvoiceSection.PaymentInfo>().single()
+        assertEquals("Pay Now", pay.paymentLink?.text)
+        assertEquals(LinkStyle.BUTTON, pay.paymentLink?.style)
+    }
+
+    @Test
+    fun paymentInfoSingleArgPaymentLinkDefaultsToPayNowText() {
+        val doc = invoice {
+            paymentInfo { paymentLink("https://pay.example.com") }
+        }
+        val pay = doc.sections.filterIsInstance<InvoiceSection.PaymentInfo>().single()
+        assertEquals("Pay Now", pay.paymentLink?.text)
+        assertEquals(LinkStyle.TEXT, pay.paymentLink?.style)
+    }
+
+    @Test
+    fun paymentInfoNotesLambdaSupportsRichElements() {
+        val doc = invoice {
+            paymentInfo {
+                notes {
+                    text("See our ")
+                    link("policy", "https://acme.com/policy")
+                }
+            }
+        }
+        val pay = doc.sections.filterIsInstance<InvoiceSection.PaymentInfo>().single()
+        assertEquals(2, pay.notes?.size)
+        assertEquals("See our ", (pay.notes!![0] as InvoiceElement.Text).value)
+        assertEquals(LinkStyle.TEXT, (pay.notes!![1] as InvoiceElement.Link).style)
+    }
 }

--- a/core/src/commonTest/kotlin/com/chrisjenx/kinvoicing/DslBuilderTest.kt
+++ b/core/src/commonTest/kotlin/com/chrisjenx/kinvoicing/DslBuilderTest.kt
@@ -487,4 +487,46 @@ class DslBuilderTest {
         assertEquals("See our ", (pay.notes!![0] as InvoiceElement.Text).value)
         assertEquals(LinkStyle.TEXT, (pay.notes!![1] as InvoiceElement.Link).style)
     }
+
+    @Test
+    fun footerNotesLambdaSupportsLinks() {
+        val doc = invoice {
+            footer {
+                notes {
+                    text("Read our ")
+                    link("terms", "https://acme.com/terms")
+                }
+            }
+        }
+        val footer = doc.sections.filterIsInstance<InvoiceSection.Footer>().single()
+        assertEquals(2, footer.notes?.size)
+        assertEquals("terms", (footer.notes!![1] as InvoiceElement.Link).text)
+    }
+
+    @Test
+    fun footerTermsLambdaSupportsButton() {
+        val doc = invoice {
+            footer {
+                terms {
+                    button("Pay Now", "https://pay.acme.com")
+                }
+            }
+        }
+        val footer = doc.sections.filterIsInstance<InvoiceSection.Footer>().single()
+        val link = footer.terms!![0] as InvoiceElement.Link
+        assertEquals(LinkStyle.BUTTON, link.style)
+    }
+
+    @Test
+    fun footerStringSettersStillWork() {
+        val doc = invoice {
+            footer {
+                notes("Thank you")
+                terms("Net 30")
+            }
+        }
+        val footer = doc.sections.filterIsInstance<InvoiceSection.Footer>().single()
+        assertEquals("Thank you", (footer.notes!![0] as InvoiceElement.Text).value)
+        assertEquals("Net 30", (footer.terms!![0] as InvoiceElement.Text).value)
+    }
 }

--- a/core/src/commonTest/kotlin/com/chrisjenx/kinvoicing/InvoiceElementTest.kt
+++ b/core/src/commonTest/kotlin/com/chrisjenx/kinvoicing/InvoiceElementTest.kt
@@ -1,0 +1,22 @@
+package com.chrisjenx.kinvoicing
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class InvoiceElementTest {
+    @Test
+    fun linkDefaultsToTextStyle() {
+        val link = InvoiceElement.Link(text = "Pay Now", href = "https://pay.example.com")
+        assertEquals(LinkStyle.TEXT, link.style)
+    }
+
+    @Test
+    fun linkAcceptsButtonStyle() {
+        val link = InvoiceElement.Link(
+            text = "Pay Now",
+            href = "https://pay.example.com",
+            style = LinkStyle.BUTTON,
+        )
+        assertEquals(LinkStyle.BUTTON, link.style)
+    }
+}

--- a/core/src/commonTest/kotlin/com/chrisjenx/kinvoicing/InvoiceSectionTest.kt
+++ b/core/src/commonTest/kotlin/com/chrisjenx/kinvoicing/InvoiceSectionTest.kt
@@ -24,7 +24,7 @@ class InvoiceSectionTest {
                 total = 100.0,
             ),
             InvoiceSection.PaymentInfo(bankName = "Bank"),
-            InvoiceSection.Footer(notes = "Thanks"),
+            InvoiceSection.Footer(notes = listOf(InvoiceElement.Text("Thanks"))),
             InvoiceSection.Custom(
                 key = "custom",
                 content = listOf(InvoiceElement.Text("Hello"))

--- a/core/src/commonTest/kotlin/com/chrisjenx/kinvoicing/builders/ContentBuilderTest.kt
+++ b/core/src/commonTest/kotlin/com/chrisjenx/kinvoicing/builders/ContentBuilderTest.kt
@@ -1,0 +1,66 @@
+package com.chrisjenx.kinvoicing.builders
+
+import com.chrisjenx.kinvoicing.InvoiceElement
+import com.chrisjenx.kinvoicing.LinkStyle
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+class ContentBuilderTest {
+    @Test
+    fun textAddsTextElement() {
+        val out = ContentBuilder().apply { text("hello") }.buildPublic()
+        assertEquals(1, out.size)
+        val t = assertIs<InvoiceElement.Text>(out[0])
+        assertEquals("hello", t.value)
+    }
+
+    @Test
+    fun linkAddsTextStyleLink() {
+        val out = ContentBuilder().apply { link("Pay Now", "https://pay.example.com") }.buildPublic()
+        val l = assertIs<InvoiceElement.Link>(out[0])
+        assertEquals("Pay Now", l.text)
+        assertEquals("https://pay.example.com", l.href)
+        assertEquals(LinkStyle.TEXT, l.style)
+    }
+
+    @Test
+    fun buttonAddsButtonStyleLink() {
+        val out = ContentBuilder().apply { button("Pay Now", "https://pay.example.com") }.buildPublic()
+        val l = assertIs<InvoiceElement.Link>(out[0])
+        assertEquals(LinkStyle.BUTTON, l.style)
+    }
+
+    @Test
+    fun linkRejectsUnsafeUrlScheme() {
+        assertFailsWith<IllegalArgumentException> {
+            ContentBuilder().apply { link("X", "javascript:alert(1)") }
+        }
+    }
+
+    @Test
+    fun buttonRejectsUnsafeUrlScheme() {
+        assertFailsWith<IllegalArgumentException> {
+            ContentBuilder().apply { button("X", "javascript:alert(1)") }
+        }
+    }
+
+    @Test
+    fun spacerDividerAndRowComposeAsExpected() {
+        val out = ContentBuilder().apply {
+            spacer(8)
+            divider()
+            row(1f, 2f) {
+                text("L")
+                text("R")
+            }
+        }.buildPublic()
+        assertEquals(3, out.size)
+        assertIs<InvoiceElement.Spacer>(out[0])
+        assertEquals(InvoiceElement.Divider, out[1])
+        val r = assertIs<InvoiceElement.Row>(out[2])
+        assertEquals(2, r.children.size)
+        assertEquals(listOf(1f, 2f), r.weights)
+    }
+}

--- a/core/src/commonTest/kotlin/com/chrisjenx/kinvoicing/builders/ContentBuilderTest.kt
+++ b/core/src/commonTest/kotlin/com/chrisjenx/kinvoicing/builders/ContentBuilderTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.assertIs
 class ContentBuilderTest {
     @Test
     fun textAddsTextElement() {
-        val out = ContentBuilder().apply { text("hello") }.buildPublic()
+        val out = ContentBuilder().apply { text("hello") }.build()
         assertEquals(1, out.size)
         val t = assertIs<InvoiceElement.Text>(out[0])
         assertEquals("hello", t.value)
@@ -18,7 +18,7 @@ class ContentBuilderTest {
 
     @Test
     fun linkAddsTextStyleLink() {
-        val out = ContentBuilder().apply { link("Pay Now", "https://pay.example.com") }.buildPublic()
+        val out = ContentBuilder().apply { link("Pay Now", "https://pay.example.com") }.build()
         val l = assertIs<InvoiceElement.Link>(out[0])
         assertEquals("Pay Now", l.text)
         assertEquals("https://pay.example.com", l.href)
@@ -27,7 +27,7 @@ class ContentBuilderTest {
 
     @Test
     fun buttonAddsButtonStyleLink() {
-        val out = ContentBuilder().apply { button("Pay Now", "https://pay.example.com") }.buildPublic()
+        val out = ContentBuilder().apply { button("Pay Now", "https://pay.example.com") }.build()
         val l = assertIs<InvoiceElement.Link>(out[0])
         assertEquals(LinkStyle.BUTTON, l.style)
     }
@@ -55,7 +55,7 @@ class ContentBuilderTest {
                 text("L")
                 text("R")
             }
-        }.buildPublic()
+        }.build()
         assertEquals(3, out.size)
         assertIs<InvoiceElement.Spacer>(out[0])
         assertEquals(InvoiceElement.Divider, out[1])

--- a/core/src/commonTest/kotlin/com/chrisjenx/kinvoicing/builders/SecurityTest.kt
+++ b/core/src/commonTest/kotlin/com/chrisjenx/kinvoicing/builders/SecurityTest.kt
@@ -201,4 +201,18 @@ class SecurityTest {
             summary {}
         }
     }
+
+    @Test
+    fun paymentLinkWithTextRejectsJavascriptScheme() {
+        assertFailsWith<IllegalArgumentException> {
+            invoice { paymentInfo { paymentLink("Click", "javascript:alert(1)") } }
+        }
+    }
+
+    @Test
+    fun paymentButtonRejectsJavascriptScheme() {
+        assertFailsWith<IllegalArgumentException> {
+            invoice { paymentInfo { paymentButton("Click", "javascript:alert(1)") } }
+        }
+    }
 }

--- a/docs/migration/1.2.0-link-button-dsl.md
+++ b/docs/migration/1.2.0-link-button-dsl.md
@@ -1,0 +1,170 @@
+---
+title: 1.2.0 — Link/Button DSL
+parent: Migration
+nav_order: 1
+---
+
+# 1.2.0 — Generic Link/Button DSL
+
+This release adds `link()` and `button()` to every block that holds free-text
+content (Custom sections, `paymentInfo { notes { ... } }`, `footer { notes/terms/customContent { ... } }`),
+introduces a `LinkStyle` choice on the pay link (TEXT or BUTTON), and refactors
+the IR so notes/terms hold rich element lists rather than flat strings.
+
+## At a glance
+
+| Surface | Status |
+|---------|--------|
+| `paymentLink("https://...")` single-arg DSL | ✅ Unchanged — still works, label defaults to `"Pay Now"` |
+| `paymentLink("Pay Now", "https://...")` | ➕ New 2/3-arg overload with optional `LinkStyle` |
+| `paymentButton("Pay Now", "https://...")` | ➕ New convenience for BUTTON style |
+| `notes("Thank you")` / `terms("Net 30")` (string form) | ✅ Unchanged |
+| `notes { text(...); link(...) }` (rich form) | ➕ New lambda overload |
+| `link(text, href)` inside Custom | ✅ Unchanged |
+| `button(text, href)` inside Custom / notes / footer | ➕ New |
+| `InvoiceSection.PaymentInfo.paymentLink: String?` | ⚠ Breaking — now `InvoiceElement.Link?` |
+| `InvoiceSection.PaymentInfo.notes: String?` | ⚠ Breaking — now `List<InvoiceElement>?` |
+| `InvoiceSection.Footer.{notes, terms, customContent}: String?` | ⚠ Breaking — now `List<InvoiceElement>?` |
+| `CustomBuilder.row { }` receiver | ⚠ Minor — now `ContentBuilder` instead of `CustomBuilder` |
+| Default rendered pay-link text | ⚠ Behaviour change — was `"Pay Online: <url>"`, now `"Pay Now"` (or your custom label) |
+
+Most user code keeps compiling because the DSL surface stayed
+backward-compatible. The breaking changes hit code that **inspects** the IR
+directly (e.g. tests, custom renderers, serialisation).
+
+## Added
+
+### `link()` and `button()` everywhere
+
+Both are part of the shared `ContentBuilder` DSL, available wherever rich
+content is accepted:
+
+```kotlin
+invoice {
+    paymentInfo {
+        bankName("First National")
+        paymentButton("Pay $1,000 Now", "https://pay.acme.com/inv-001")
+        notes {
+            text("Wire transfer alternative — see ")
+            link("transfer policy", "https://acme.com/wire-policy")
+        }
+    }
+    footer {
+        notes {
+            text("Thanks for your business! Read our ")
+            link("terms", "https://acme.com/terms")
+            text(" or ")
+            link("contact support", "mailto:billing@acme.com")
+            text(".")
+        }
+    }
+    custom("cta") {
+        button("Schedule a call", "https://cal.com/acme")
+    }
+}
+```
+
+### `LinkStyle` enum
+
+```kotlin
+public enum class LinkStyle { TEXT, BUTTON }
+```
+
+Attached to `InvoiceElement.Link.style`. TEXT renders as primary-colored M3
+`labelLarge`. BUTTON renders as an M3 `Button`-equivalent (filled primary
+container, white label, 20dp pill, 24dp/10dp padding, 14sp Medium label).
+
+### `paymentInfo { paymentLink(text, href, style?) }` and `paymentButton(text, href)`
+
+```kotlin
+paymentInfo {
+    paymentLink("https://...")                                     // "Pay Now", TEXT (unchanged)
+    paymentLink("Pay this invoice", "https://...")                 // custom label, TEXT
+    paymentLink("Pay Now", "https://...", LinkStyle.BUTTON)        // BUTTON
+    paymentButton("Pay $1,000 Now", "https://...")                 // BUTTON shortcut
+}
+```
+
+## Changed (breaking)
+
+### `PaymentInfo.paymentLink: String?` → `InvoiceElement.Link?`
+
+```kotlin
+// Before
+val pay: InvoiceSection.PaymentInfo = ...
+val url: String? = pay.paymentLink
+
+// After
+val link: InvoiceElement.Link? = pay.paymentLink
+val url: String? = link?.href
+val label: String? = link?.text
+val style: LinkStyle? = link?.style
+```
+
+### `PaymentInfo.notes` and `Footer.{notes, terms, customContent}` are now `List<InvoiceElement>?`
+
+```kotlin
+// Before
+val notes: String? = footer.notes
+
+// After
+val notes: List<InvoiceElement>? = footer.notes
+// Plain-text consumers can flatten:
+val plain: String = footer.notes
+    ?.joinToString("") { (it as? InvoiceElement.Text)?.value ?: "" }
+    ?: ""
+```
+
+The DSL string-form setters are unchanged:
+
+```kotlin
+footer {
+    notes("Thank you for your business!")  // still works
+    terms("Net 30")                         // still works
+}
+```
+
+### `CustomBuilder.row { }` receiver narrowed
+
+```kotlin
+// Signature before
+public fun row(vararg weights: Float, init: CustomBuilder.() -> Unit)
+
+// Signature after
+public fun row(vararg weights: Float, init: ContentBuilder.() -> Unit)
+```
+
+Inside a `row { }` block you now have only content primitives — `text()`,
+`link()`, `button()`, etc. You cannot reference the section `key`.
+
+### Pay-link default text
+
+The rendered text is now `Link.text` directly (default `"Pay Now"`), not
+`"Pay Online: <url>"`. This affects visual snapshots and any test that
+asserted on the literal string.
+
+## Removed
+
+- `PdfRendererTest.paymentLinkAnnotationPresent` — substring check on PDF text;
+  superseded by `fidelity-test/LinkAndImageTest.pdf_paymentLinkIsAnnotation`
+  which inspects real `PDAnnotationLink` + `PDActionURI`.
+
+## Renderer behaviour matrix
+
+| Element | render-compose | render-pdf | render-html-email |
+|---------|----------------|------------|-------------------|
+| `link()` (TEXT) | Primary M3 labelLarge text, wrapped in `LocalLinkWrapper` | `PdfLink` annotation over the text bounds | `<a href>` with primary color, weight 500, no underline |
+| `button()` / `paymentButton()` (BUTTON) | `Box` with primary background, 20dp pill, white label | `PdfLink` annotation over the button bounds (rect of the Box) | Bulletproof `<table><tr><td>` with primary background, 20px radius, 10/24 padding, white label |
+| Inline links inside `notes` / `terms` / `customContent` | Each element delegated to shared `ElementContent` composable | Inherits clickability via `LocalLinkWrapper` | Each element delegated to shared `renderElement` |
+
+## Suggested migration path
+
+1. **DSL-only consumers**: rebuild — most code keeps working. Visual snapshot
+   tests of pay-link rendering will need re-baselining (text changed from
+   `"Pay Online: <url>"` to your label / `"Pay Now"`).
+2. **IR consumers** (custom renderers, JSON serialisation, etc.): update field
+   accesses per the patterns above.
+3. **New invoices**: prefer the rich `notes { ... }` lambda for any text that
+   benefits from inline links — terms, support contact, policy references.
+   Use `paymentButton(...)` for the primary CTA when you want a styled button;
+   stick with `paymentLink(...)` for an inline text-style link.

--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -1,0 +1,10 @@
+---
+title: Migration
+nav_order: 9
+has_children: true
+---
+
+# Migration guides
+
+Version-by-version notes on breaking changes, new APIs, and recommended
+migration paths.

--- a/docs/sections/custom.md
+++ b/docs/sections/custom.md
@@ -60,11 +60,27 @@ row(2f, 1f) {       // 2:1 ratio columns
 }
 ```
 
-### Link
+### Link (inline text)
 
 ```kotlin
 link("View terms", "https://example.com/terms")
 ```
+
+Renders as a primary-colored Material 3 `labelLarge` inline link. Clickable in
+PDF and HTML email.
+
+### Button (styled CTA)
+
+```kotlin
+button("Pay Now", "https://pay.example.com/inv-001")
+```
+
+Renders as an M3 `Button`-equivalent — primary container, white label, 20dp pill
+corners. In email HTML this becomes a bulletproof `<table>`-wrapped button. In
+PDF the bounding rectangle becomes a clickable annotation.
+
+`link()` and `button()` are also available inside `paymentInfo { notes { ... } }`
+and `footer { notes { ... } }` / `terms { ... }` / `customContent { ... }`.
 
 ### Image
 
@@ -76,12 +92,17 @@ image(pngBytes, "image/png", width = 200, height = 100)
 
 ### CustomBuilder
 
+`CustomBuilder` extends `ContentBuilder`, so the same `link()`/`button()`/`text()`/etc.
+surface is available wherever rich content is accepted (Custom sections,
+`paymentInfo { notes { ... } }`, `footer { notes/terms/customContent { ... } }`).
+
 | Method | Description |
 |--------|-------------|
 | `text(value, styleRef?)` | Text element with optional style reference |
 | `divider()` | Horizontal divider line |
 | `spacer(height = 16)` | Vertical whitespace |
 | `row(vararg weights) { }` | Horizontal layout with column weights |
-| `link(text, href)` | Hyperlink |
+| `link(text, href)` | Inline TEXT-style hyperlink (primary color, M3 labelLarge) |
+| `button(text, href)` | BUTTON-style CTA (filled primary container, white label) |
 | `image(data, contentType, width?, height?)` | Inline image from bytes |
 | `image(source, width?, height?)` | Inline image from `ImageSource` |

--- a/docs/sections/footer.md
+++ b/docs/sections/footer.md
@@ -6,7 +6,7 @@ nav_order: 6
 
 # Footer
 
-The footer section displays notes and terms at the bottom of the invoice.
+The footer section displays notes, terms, and free-form custom content at the bottom of the invoice.
 
 ```kotlin
 footer {
@@ -16,6 +16,36 @@ footer {
 ```
 
 {% include example-preview.html name="section-footer" height="200px" %}
+
+## Inline links and rich content
+
+Each of `notes`, `terms`, and `customContent` accepts a content lambda — embed
+links, buttons, dividers, and other inline elements:
+
+```kotlin
+footer {
+    notes {
+        text("Thanks for your business! Read our ")
+        link("terms", "https://acme.com/terms")
+        text(" or ")
+        link("contact support", "mailto:billing@acme.com")
+        text(".")
+    }
+    terms {
+        text("Net 30. ")
+        link("Late payment policy", "https://acme.com/late-payment")
+    }
+}
+```
+
+Plain-string forms still work for simple cases:
+
+```kotlin
+footer {
+    notes("Thank you for your business!")
+    terms("Net 30")
+}
+```
 
 ## Powered-by Branding
 
@@ -45,5 +75,9 @@ footer {
 
 | Method | Description |
 |--------|-------------|
-| `notes(value)` | Thank-you message or general notes |
-| `terms(value)` | Payment terms and conditions |
+| `notes(value)` | Thank-you message or general notes (plain string) |
+| `notes { ... }` | Rich notes — `text()`, `link()`, `button()`, etc. |
+| `terms(value)` | Payment terms and conditions (plain string) |
+| `terms { ... }` | Rich terms |
+| `customContent(value)` | Free-form content rendered below notes/terms (plain string) |
+| `customContent { ... }` | Rich custom content |

--- a/docs/sections/payment-info.md
+++ b/docs/sections/payment-info.md
@@ -6,7 +6,7 @@ nav_order: 5
 
 # Payment Info
 
-The payment info section displays bank details, payment links, and additional notes.
+The payment info section displays bank details, a "Pay Now" call-to-action, and additional notes.
 
 ```kotlin
 paymentInfo {
@@ -20,6 +20,60 @@ paymentInfo {
 
 {% include example-preview.html name="section-payment-info" height="250px" %}
 
+## Pay Now: text link or styled button
+
+The pay link can render two ways across all renderers (Compose, PDF, Email HTML).
+Choose per invoice.
+
+### Text link (default — markdown-style `[Text](url)`)
+
+```kotlin
+paymentInfo {
+    paymentLink("https://pay.example.com/inv-001")              // label defaults to "Pay Now"
+    paymentLink("Pay this invoice", "https://pay.example.com")  // custom label, TEXT style
+}
+```
+
+Renders as a primary-colored Material 3 `labelLarge` inline link.
+
+### Styled CTA button
+
+```kotlin
+paymentInfo {
+    paymentButton("Pay $1,000 Now", "https://pay.example.com/inv-001")
+    // or, equivalently:
+    paymentLink("Pay $1,000 Now", "https://pay.example.com/inv-001", LinkStyle.BUTTON)
+}
+```
+
+Renders as an M3 `Button`-equivalent — primary container, white label, 20dp pill
+corners, 24dp/10dp padding. In email HTML this becomes a bulletproof
+`<table>`-wrapped button (Outlook-friendly). In PDF this remains clickable via
+compose2pdf's `PdfLink`.
+
+## Inline links inside notes
+
+`notes` accepts a content lambda — embed text and links anywhere:
+
+```kotlin
+paymentInfo {
+    bankName("First National")
+    paymentLink("https://pay.example.com/inv-001")
+    notes {
+        text("Wire transfer alternative — see ")
+        link("transfer policy", "https://example.com/wire-policy")
+    }
+}
+```
+
+The plain-string form still works:
+
+```kotlin
+paymentInfo {
+    notes("Wire transfers preferred for amounts over $1,000.")
+}
+```
+
 ## Builder Reference
 
 ### PaymentInfoBuilder
@@ -29,6 +83,9 @@ paymentInfo {
 | `bankName(value)` | Bank or financial institution name |
 | `accountNumber(value)` | Account number |
 | `routingNumber(value)` | Routing/sort code |
-| `paymentLink(value)` | Online payment URL |
+| `paymentLink(href)` | Pay link with default label "Pay Now", TEXT style |
+| `paymentLink(text, href, style = LinkStyle.TEXT)` | Pay link with custom label and explicit style |
+| `paymentButton(text, href)` | Convenience — equivalent to `paymentLink(text, href, LinkStyle.BUTTON)` |
 | `qrCodeData(value)` | QR code payload (renderer-dependent) |
-| `notes(value)` | Additional payment instructions |
+| `notes(value)` | Additional payment instructions (plain string) |
+| `notes { ... }` | Rich notes — supports `text()`, `link()`, `button()`, `spacer()`, `divider()`, `image()`, `row()` |

--- a/fidelity-test/src/jvmTest/kotlin/com/chrisjenx/kinvoicing/fidelity/LinkAndImageTest.kt
+++ b/fidelity-test/src/jvmTest/kotlin/com/chrisjenx/kinvoicing/fidelity/LinkAndImageTest.kt
@@ -19,6 +19,7 @@ import kotlin.test.*
 class LinkAndImageTest {
 
     private val fixture = InvoiceFixtures.linksAndImages
+    private val payButton = InvoiceFixtures.payButton
 
     // ── HTML Email Link Tests ──
 
@@ -199,6 +200,69 @@ class LinkAndImageTest {
         val pdfUris = extractPdfLinkUris(fixture.toPdf()).toSet()
         val missingFromPdf = expectedUrls - pdfUris
         assertTrue(missingFromPdf.isEmpty(), "PDF missing link annotations: $missingFromPdf")
+    }
+
+    // ── BUTTON-style and rich-notes cross-renderer assertions ──
+
+    @Test
+    fun pdf_payButtonProducesAnnotation() {
+        val uris = extractPdfLinkUris(payButton.toPdf())
+        assertTrue(
+            "https://pay.acme.com/inv-paybtn" in uris,
+            "PDF should have BUTTON-style payment link annotation, found: $uris",
+        )
+    }
+
+    @Test
+    fun htmlEmail_payButtonRendersInsideTable() {
+        val html = payButton.toHtml()
+        val anchorIdx = html.indexOf("href=\"https://pay.acme.com/inv-paybtn\"")
+        assertTrue(anchorIdx >= 0, "Expected payment link <a> in BUTTON-style HTML")
+        val precedingHtml = html.substring(0, anchorIdx)
+        val tableIdx = precedingHtml.lastIndexOf("<table")
+        val tdIdx = precedingHtml.lastIndexOf("<td")
+        assertTrue(
+            tableIdx >= 0 && tdIdx > tableIdx,
+            "BUTTON-style payment link should be wrapped in <table><tr><td>",
+        )
+    }
+
+    @Test
+    fun pdf_paymentNotesEmbeddedLinkProducesAnnotation() {
+        val uris = extractPdfLinkUris(payButton.toPdf())
+        assertTrue(
+            "https://acme.com/wire-policy" in uris,
+            "PDF should annotate inline link in PaymentInfo.notes, found: $uris",
+        )
+    }
+
+    @Test
+    fun htmlEmail_paymentNotesEmbeddedLinkRenders() {
+        val html = payButton.toHtml()
+        assertTrue(
+            "href=\"https://acme.com/wire-policy\"" in html,
+            "PaymentInfo.notes inline link should render as <a href>",
+        )
+    }
+
+    @Test
+    fun pdf_footerEmbeddedLinkProducesAnnotation() {
+        val uris = extractPdfLinkUris(payButton.toPdf())
+        assertTrue(
+            "https://acme.com/terms" in uris,
+            "PDF should annotate inline link in Footer.notes, found: $uris",
+        )
+        assertTrue(
+            "mailto:billing@acme.com" in uris,
+            "PDF should annotate mailto: link in Footer.notes, found: $uris",
+        )
+    }
+
+    @Test
+    fun htmlEmail_footerEmbeddedLinkRenders() {
+        val html = payButton.toHtml()
+        assertTrue("href=\"https://acme.com/terms\"" in html, "Footer.notes link should render")
+        assertTrue("href=\"mailto:billing@acme.com\"" in html, "Footer.notes mailto: link should render")
     }
 
     // ── Helper ──

--- a/kinvoicing-docs/build.gradle.kts
+++ b/kinvoicing-docs/build.gradle.kts
@@ -11,5 +11,15 @@ application {
 dependencies {
     implementation(project(":core"))
     implementation(project(":render-html-email"))
+    implementation(project(":render-pdf"))
     implementation(project(":kinvoicing-examples"))
+    implementation(libs.pdfbox)
+}
+
+tasks.register<JavaExec>("renderPreviews") {
+    group = "documentation"
+    description = "Render payButton + linksAndImages fixtures to HTML, PDF, and PNG previews."
+    classpath = sourceSets["main"].runtimeClasspath
+    mainClass.set("com.chrisjenx.kinvoicing.docs.RenderPreviewsKt")
+    systemProperty("project.root", rootProject.projectDir.absolutePath)
 }

--- a/kinvoicing-docs/src/main/kotlin/com/chrisjenx/kinvoicing/docs/RenderPreviews.kt
+++ b/kinvoicing-docs/src/main/kotlin/com/chrisjenx/kinvoicing/docs/RenderPreviews.kt
@@ -1,0 +1,41 @@
+package com.chrisjenx.kinvoicing.docs
+
+import com.chrisjenx.kinvoicing.InvoiceDocument
+import com.chrisjenx.kinvoicing.InvoiceFixtures
+import com.chrisjenx.kinvoicing.html.email.toHtml
+import com.chrisjenx.kinvoicing.pdf.toPdf
+import org.apache.pdfbox.Loader
+import org.apache.pdfbox.rendering.ImageType
+import org.apache.pdfbox.rendering.PDFRenderer
+import java.io.File
+import javax.imageio.ImageIO
+
+/**
+ * One-shot preview generator. Renders selected fixtures to HTML, PDF, and a
+ * rasterised PNG of the first PDF page, into an output directory.
+ *
+ * Args: [outputDir] (defaults to /tmp/kinvoicing-renders).
+ */
+fun main(args: Array<String>) {
+    val outDir = File(args.firstOrNull() ?: "/tmp/kinvoicing-renders").apply { mkdirs() }
+
+    val previews: List<Pair<String, InvoiceDocument>> = listOf(
+        "payButton" to InvoiceFixtures.payButton,
+        "linksAndImages" to InvoiceFixtures.linksAndImages,
+    )
+
+    for ((name, doc) in previews) {
+        val html = File(outDir, "$name.html").apply { writeText(doc.toHtml()) }
+        val pdf = File(outDir, "$name.pdf").apply { writeBytes(doc.toPdf()) }
+        val png = File(outDir, "$name.page1.png")
+
+        Loader.loadPDF(pdf).use { pdfDoc ->
+            val image = PDFRenderer(pdfDoc).renderImageWithDPI(0, 144f, ImageType.RGB)
+            ImageIO.write(image, "PNG", png)
+        }
+
+        println("Rendered $name → $html, $pdf, $png")
+    }
+
+    println("Done. Open the PNGs/PDFs in ${outDir.absolutePath}")
+}

--- a/render-compose/src/commonMain/kotlin/com/chrisjenx/kinvoicing/compose/sections/CustomSection.kt
+++ b/render-compose/src/commonMain/kotlin/com/chrisjenx/kinvoicing/compose/sections/CustomSection.kt
@@ -1,65 +1,14 @@
 package com.chrisjenx.kinvoicing.compose.sections
 
-import androidx.compose.foundation.layout.*
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Text
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
-import com.chrisjenx.kinvoicing.InvoiceElement
 import com.chrisjenx.kinvoicing.InvoiceSection
-import com.chrisjenx.kinvoicing.compose.*
 
 @Composable
 internal fun CustomSection(custom: InvoiceSection.Custom) {
     Column(modifier = Modifier.fillMaxWidth()) {
-        custom.content.forEach { element ->
-            ElementContent(element)
-        }
-    }
-}
-
-@Composable
-private fun ElementContent(element: InvoiceElement) {
-    val style = LocalInvoiceStyle.current
-
-    when (element) {
-        is InvoiceElement.Text -> {
-            Text(
-                text = element.value,
-                fontSize = InvoiceTypography.bodyLarge,
-                color = style.textComposeColor,
-            )
-        }
-        is InvoiceElement.Spacer -> {
-            Spacer(modifier = Modifier.height(element.height.dp))
-        }
-        is InvoiceElement.Divider -> {
-            HorizontalDivider(color = style.borderComposeColor, modifier = Modifier.padding(vertical = InvoiceSpacing.sm))
-        }
-        is InvoiceElement.Row -> {
-            Row(modifier = Modifier.fillMaxWidth()) {
-                element.children.forEachIndexed { i, child ->
-                    val weight = if (i < element.weights.size) element.weights[i] else 1f
-                    Box(modifier = Modifier.weight(weight)) {
-                        ElementContent(child)
-                    }
-                }
-            }
-        }
-        is InvoiceElement.Link -> {
-            val linkWrapper = LocalLinkWrapper.current
-            linkWrapper(element.href) {
-                Text(
-                    text = element.text,
-                    fontSize = InvoiceTypography.bodyLarge,
-                    color = style.primaryComposeColor,
-                )
-            }
-        }
-        is InvoiceElement.Image -> {
-            val imageRenderer = LocalImageRenderer.current
-            imageRenderer(element.source, element.width, element.height, null)
-        }
+        custom.content.forEach { ElementContent(it) }
     }
 }

--- a/render-compose/src/commonMain/kotlin/com/chrisjenx/kinvoicing/compose/sections/ElementContent.kt
+++ b/render-compose/src/commonMain/kotlin/com/chrisjenx/kinvoicing/compose/sections/ElementContent.kt
@@ -1,0 +1,87 @@
+package com.chrisjenx.kinvoicing.compose.sections
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.chrisjenx.kinvoicing.InvoiceElement
+import com.chrisjenx.kinvoicing.LinkStyle
+import com.chrisjenx.kinvoicing.compose.*
+
+/**
+ * Renders any [InvoiceElement] to Compose UI. Single source of truth for how
+ * inline content (text, links, buttons, dividers, images, rows) is presented.
+ *
+ * Used by [CustomSection], [PaymentInfoSection], and [FooterSection].
+ */
+@Composable
+internal fun ElementContent(element: InvoiceElement) {
+    val style = LocalInvoiceStyle.current
+    when (element) {
+        is InvoiceElement.Text -> Text(
+            text = element.value,
+            fontSize = InvoiceTypography.bodyLarge,
+            color = style.textComposeColor,
+        )
+
+        is InvoiceElement.Spacer -> Spacer(modifier = Modifier.height(element.height.dp))
+
+        is InvoiceElement.Divider -> HorizontalDivider(
+            color = style.borderComposeColor,
+            modifier = Modifier.padding(vertical = InvoiceSpacing.sm),
+        )
+
+        is InvoiceElement.Row -> Row(modifier = Modifier.fillMaxWidth()) {
+            element.children.forEachIndexed { i, child ->
+                val weight = if (i < element.weights.size) element.weights[i] else 1f
+                Box(modifier = Modifier.weight(weight)) {
+                    ElementContent(child)
+                }
+            }
+        }
+
+        is InvoiceElement.Link -> {
+            val linkWrapper = LocalLinkWrapper.current
+            when (element.style) {
+                LinkStyle.TEXT -> linkWrapper(element.href) {
+                    Text(
+                        text = element.text,
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Medium,
+                        color = style.primaryComposeColor,
+                    )
+                }
+                LinkStyle.BUTTON -> linkWrapper(element.href) {
+                    // Visual-only equivalent of M3 FilledButton — onClick handled by linkWrapper.
+                    Box(
+                        modifier = Modifier
+                            .heightIn(min = 40.dp)
+                            .background(style.primaryComposeColor, RoundedCornerShape(20.dp))
+                            .padding(horizontal = 24.dp, vertical = 10.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = element.text,
+                            fontSize = 14.sp,
+                            fontWeight = FontWeight.Medium,
+                            color = Color.White,
+                        )
+                    }
+                }
+            }
+        }
+
+        is InvoiceElement.Image -> {
+            val imageRenderer = LocalImageRenderer.current
+            imageRenderer(element.source, element.width, element.height, null)
+        }
+    }
+}

--- a/render-compose/src/commonMain/kotlin/com/chrisjenx/kinvoicing/compose/sections/ElementContent.kt
+++ b/render-compose/src/commonMain/kotlin/com/chrisjenx/kinvoicing/compose/sections/ElementContent.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.chrisjenx.kinvoicing.InvoiceElement
 import com.chrisjenx.kinvoicing.LinkStyle
 import com.chrisjenx.kinvoicing.compose.*
@@ -54,13 +53,12 @@ internal fun ElementContent(element: InvoiceElement) {
                 LinkStyle.TEXT -> linkWrapper(element.href) {
                     Text(
                         text = element.text,
-                        fontSize = 14.sp,
+                        fontSize = InvoiceTypography.bodyLarge,
                         fontWeight = FontWeight.Medium,
                         color = style.primaryComposeColor,
                     )
                 }
                 LinkStyle.BUTTON -> linkWrapper(element.href) {
-                    // Visual-only equivalent of M3 FilledButton — onClick handled by linkWrapper.
                     Box(
                         modifier = Modifier
                             .heightIn(min = 40.dp)
@@ -70,7 +68,7 @@ internal fun ElementContent(element: InvoiceElement) {
                     ) {
                         Text(
                             text = element.text,
-                            fontSize = 14.sp,
+                            fontSize = InvoiceTypography.bodyLarge,
                             fontWeight = FontWeight.Medium,
                             color = Color.White,
                         )

--- a/render-compose/src/commonMain/kotlin/com/chrisjenx/kinvoicing/compose/sections/FooterSection.kt
+++ b/render-compose/src/commonMain/kotlin/com/chrisjenx/kinvoicing/compose/sections/FooterSection.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.chrisjenx.kinvoicing.BrandLayout
 import com.chrisjenx.kinvoicing.Branding
+import com.chrisjenx.kinvoicing.InvoiceElement
 import com.chrisjenx.kinvoicing.InvoiceSection
 import com.chrisjenx.kinvoicing.compose.*
 
@@ -26,7 +27,7 @@ internal fun FooterSection(footer: InvoiceSection.Footer, branding: Branding? = 
             .background(style.mutedBgComposeColor, RoundedCornerShape(4.dp))
             .padding(InvoiceSpacing.lg),
     ) {
-        footer.notes?.let {
+        footer.notes?.let { elements ->
             Text(
                 text = "NOTES",
                 fontSize = InvoiceTypography.caption,
@@ -34,10 +35,11 @@ internal fun FooterSection(footer: InvoiceSection.Footer, branding: Branding? = 
                 color = style.secondaryComposeColor,
             )
             Spacer(modifier = Modifier.height(InvoiceSpacing.xs))
-            Text(text = it, fontSize = InvoiceTypography.bodyMedium, color = style.secondaryComposeColor)
+            val flattened = elements.joinToString("") { (it as? InvoiceElement.Text)?.value ?: "" }
+            Text(text = flattened, fontSize = InvoiceTypography.bodyMedium, color = style.secondaryComposeColor)
             Spacer(modifier = Modifier.height(InvoiceSpacing.sm))
         }
-        footer.terms?.let {
+        footer.terms?.let { elements ->
             Text(
                 text = "TERMS",
                 fontSize = InvoiceTypography.caption,
@@ -45,11 +47,13 @@ internal fun FooterSection(footer: InvoiceSection.Footer, branding: Branding? = 
                 color = style.secondaryComposeColor,
             )
             Spacer(modifier = Modifier.height(InvoiceSpacing.xs))
-            Text(text = it, fontSize = InvoiceTypography.bodySmall, color = style.secondaryComposeColor)
+            val flattened = elements.joinToString("") { (it as? InvoiceElement.Text)?.value ?: "" }
+            Text(text = flattened, fontSize = InvoiceTypography.bodySmall, color = style.secondaryComposeColor)
         }
-        footer.customContent?.let {
+        footer.customContent?.let { elements ->
             Spacer(modifier = Modifier.height(InvoiceSpacing.sm))
-            Text(text = it, fontSize = InvoiceTypography.bodySmall, color = style.secondaryComposeColor)
+            val flattened = elements.joinToString("") { (it as? InvoiceElement.Text)?.value ?: "" }
+            Text(text = flattened, fontSize = InvoiceTypography.bodySmall, color = style.secondaryComposeColor)
         }
         val pb = branding?.takeIf { it.layout == BrandLayout.POWERED_BY_FOOTER }?.poweredBy
         if (pb != null) {

--- a/render-compose/src/commonMain/kotlin/com/chrisjenx/kinvoicing/compose/sections/FooterSection.kt
+++ b/render-compose/src/commonMain/kotlin/com/chrisjenx/kinvoicing/compose/sections/FooterSection.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.chrisjenx.kinvoicing.BrandLayout
 import com.chrisjenx.kinvoicing.Branding
-import com.chrisjenx.kinvoicing.InvoiceElement
 import com.chrisjenx.kinvoicing.InvoiceSection
 import com.chrisjenx.kinvoicing.compose.*
 
@@ -35,8 +34,7 @@ internal fun FooterSection(footer: InvoiceSection.Footer, branding: Branding? = 
                 color = style.secondaryComposeColor,
             )
             Spacer(modifier = Modifier.height(InvoiceSpacing.xs))
-            val flattened = elements.joinToString("") { (it as? InvoiceElement.Text)?.value ?: "" }
-            Text(text = flattened, fontSize = InvoiceTypography.bodyMedium, color = style.secondaryComposeColor)
+            elements.forEach { ElementContent(it) }
             Spacer(modifier = Modifier.height(InvoiceSpacing.sm))
         }
         footer.terms?.let { elements ->
@@ -47,13 +45,11 @@ internal fun FooterSection(footer: InvoiceSection.Footer, branding: Branding? = 
                 color = style.secondaryComposeColor,
             )
             Spacer(modifier = Modifier.height(InvoiceSpacing.xs))
-            val flattened = elements.joinToString("") { (it as? InvoiceElement.Text)?.value ?: "" }
-            Text(text = flattened, fontSize = InvoiceTypography.bodySmall, color = style.secondaryComposeColor)
+            elements.forEach { ElementContent(it) }
         }
         footer.customContent?.let { elements ->
             Spacer(modifier = Modifier.height(InvoiceSpacing.sm))
-            val flattened = elements.joinToString("") { (it as? InvoiceElement.Text)?.value ?: "" }
-            Text(text = flattened, fontSize = InvoiceTypography.bodySmall, color = style.secondaryComposeColor)
+            elements.forEach { ElementContent(it) }
         }
         val pb = branding?.takeIf { it.layout == BrandLayout.POWERED_BY_FOOTER }?.poweredBy
         if (pb != null) {

--- a/render-compose/src/commonMain/kotlin/com/chrisjenx/kinvoicing/compose/sections/PaymentInfoSection.kt
+++ b/render-compose/src/commonMain/kotlin/com/chrisjenx/kinvoicing/compose/sections/PaymentInfoSection.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.chrisjenx.kinvoicing.InvoiceElement
 import com.chrisjenx.kinvoicing.InvoiceSection
 import com.chrisjenx.kinvoicing.compose.*
 
@@ -20,7 +19,7 @@ internal fun PaymentInfoSection(payment: InvoiceSection.PaymentInfo) {
         modifier = Modifier
             .fillMaxWidth()
             .background(style.mutedBgComposeColor, RoundedCornerShape(4.dp))
-            .padding(InvoiceSpacing.lg)
+            .padding(InvoiceSpacing.lg),
     ) {
         Text(
             text = "PAYMENT INFORMATION",
@@ -40,21 +39,12 @@ internal fun PaymentInfoSection(payment: InvoiceSection.PaymentInfo) {
             Text(text = "Routing: $it", fontSize = InvoiceTypography.bodyMedium, color = style.textComposeColor)
         }
         payment.paymentLink?.let { link ->
-            val linkWrapper = LocalLinkWrapper.current
             Spacer(modifier = Modifier.height(InvoiceSpacing.sm))
-            linkWrapper(link.href) {
-                Text(
-                    text = link.text,
-                    fontSize = InvoiceTypography.bodyLarge,
-                    fontWeight = FontWeight.Bold,
-                    color = style.primaryComposeColor,
-                )
-            }
+            ElementContent(link)
         }
         payment.notes?.let { elements ->
             Spacer(modifier = Modifier.height(InvoiceSpacing.sm))
-            val flattened = elements.joinToString("") { (it as? InvoiceElement.Text)?.value ?: "" }
-            Text(text = flattened, fontSize = InvoiceTypography.bodySmall, color = style.secondaryComposeColor)
+            elements.forEach { ElementContent(it) }
         }
     }
 }

--- a/render-compose/src/commonMain/kotlin/com/chrisjenx/kinvoicing/compose/sections/PaymentInfoSection.kt
+++ b/render-compose/src/commonMain/kotlin/com/chrisjenx/kinvoicing/compose/sections/PaymentInfoSection.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.chrisjenx.kinvoicing.InvoiceElement
 import com.chrisjenx.kinvoicing.InvoiceSection
 import com.chrisjenx.kinvoicing.compose.*
 
@@ -41,18 +42,19 @@ internal fun PaymentInfoSection(payment: InvoiceSection.PaymentInfo) {
         payment.paymentLink?.let { link ->
             val linkWrapper = LocalLinkWrapper.current
             Spacer(modifier = Modifier.height(InvoiceSpacing.sm))
-            linkWrapper(link) {
+            linkWrapper(link.href) {
                 Text(
-                    text = "Pay Online: $link",
+                    text = link.text,
                     fontSize = InvoiceTypography.bodyLarge,
                     fontWeight = FontWeight.Bold,
                     color = style.primaryComposeColor,
                 )
             }
         }
-        payment.notes?.let {
+        payment.notes?.let { elements ->
             Spacer(modifier = Modifier.height(InvoiceSpacing.sm))
-            Text(text = it, fontSize = InvoiceTypography.bodySmall, color = style.secondaryComposeColor)
+            val flattened = elements.joinToString("") { (it as? InvoiceElement.Text)?.value ?: "" }
+            Text(text = flattened, fontSize = InvoiceTypography.bodySmall, color = style.secondaryComposeColor)
         }
     }
 }

--- a/render-html-email/src/commonMain/kotlin/com/chrisjenx/kinvoicing/html/email/sections/CustomHtml.kt
+++ b/render-html-email/src/commonMain/kotlin/com/chrisjenx/kinvoicing/html/email/sections/CustomHtml.kt
@@ -41,12 +41,31 @@ internal fun FlowContent.renderElement(element: InvoiceElement, style: InvoiceSt
                 }
             }
         }
-        is InvoiceElement.Link -> {
-            div {
+        is InvoiceElement.Link -> when (element.style) {
+            LinkStyle.TEXT -> div {
                 a {
                     href = requireSafeUrl(element.href, "href")
-                    attributes["style"] = "font-size: 14px; color: ${style.primaryColor.toHexColor()}; text-decoration: none; font-weight: bold;"
+                    attributes["style"] =
+                        "font-size:14px; color:${style.primaryColor.toHexColor()}; font-weight:500; text-decoration:none;"
                     +element.text
+                }
+            }
+            LinkStyle.BUTTON -> table {
+                attributes["cellpadding"] = "0"
+                attributes["cellspacing"] = "0"
+                attributes["border"] = "0"
+                attributes["style"] = "margin: 8px 0;"
+                tr {
+                    td {
+                        attributes["style"] =
+                            "background:${style.primaryColor.toHexColor()}; border-radius:20px; padding:10px 24px;"
+                        a {
+                            href = requireSafeUrl(element.href, "href")
+                            attributes["style"] =
+                                "color:#ffffff; font-weight:500; font-size:14px; text-decoration:none; display:inline-block;"
+                            +element.text
+                        }
+                    }
                 }
             }
         }

--- a/render-html-email/src/commonMain/kotlin/com/chrisjenx/kinvoicing/html/email/sections/FooterHtml.kt
+++ b/render-html-email/src/commonMain/kotlin/com/chrisjenx/kinvoicing/html/email/sections/FooterHtml.kt
@@ -7,22 +7,25 @@ import kotlinx.html.*
 internal fun FlowContent.renderFooter(footer: InvoiceSection.Footer, style: InvoiceStyle, branding: Branding? = null) {
     div {
         attributes["style"] = "padding: 16px; background-color: ${style.mutedBackgroundColor.toHexColor()}; border-radius: 4px;"
-        footer.notes?.let {
+        footer.notes?.let { elements ->
             div {
                 attributes["style"] = "font-size: 11px; font-weight: bold; text-transform: uppercase; color: ${style.secondaryColor.toHexColor()}; margin-bottom: 4px;"
                 +"Notes"
             }
-            div { attributes["style"] = "font-size: 13px; color: ${style.secondaryColor.toHexColor()}; margin-bottom: 8px;" ; +it }
+            val flattened = elements.joinToString("") { (it as? InvoiceElement.Text)?.value ?: "" }
+            div { attributes["style"] = "font-size: 13px; color: ${style.secondaryColor.toHexColor()}; margin-bottom: 8px;" ; +flattened }
         }
-        footer.terms?.let {
+        footer.terms?.let { elements ->
             div {
                 attributes["style"] = "font-size: 11px; font-weight: bold; text-transform: uppercase; color: ${style.secondaryColor.toHexColor()}; margin-bottom: 4px;"
                 +"Terms"
             }
-            div { attributes["style"] = "font-size: 12px; color: ${style.secondaryColor.toHexColor()};" ; +it }
+            val flattened = elements.joinToString("") { (it as? InvoiceElement.Text)?.value ?: "" }
+            div { attributes["style"] = "font-size: 12px; color: ${style.secondaryColor.toHexColor()};" ; +flattened }
         }
-        footer.customContent?.let {
-            div { attributes["style"] = "font-size: 12px; color: ${style.secondaryColor.toHexColor()}; margin-top: 8px;" ; +it }
+        footer.customContent?.let { elements ->
+            val flattened = elements.joinToString("") { (it as? InvoiceElement.Text)?.value ?: "" }
+            div { attributes["style"] = "font-size: 12px; color: ${style.secondaryColor.toHexColor()}; margin-top: 8px;" ; +flattened }
         }
         val pb = branding?.takeIf { it.layout == BrandLayout.POWERED_BY_FOOTER }?.poweredBy
         if (pb != null) {

--- a/render-html-email/src/commonMain/kotlin/com/chrisjenx/kinvoicing/html/email/sections/FooterHtml.kt
+++ b/render-html-email/src/commonMain/kotlin/com/chrisjenx/kinvoicing/html/email/sections/FooterHtml.kt
@@ -12,20 +12,26 @@ internal fun FlowContent.renderFooter(footer: InvoiceSection.Footer, style: Invo
                 attributes["style"] = "font-size: 11px; font-weight: bold; text-transform: uppercase; color: ${style.secondaryColor.toHexColor()}; margin-bottom: 4px;"
                 +"Notes"
             }
-            val flattened = elements.joinToString("") { (it as? InvoiceElement.Text)?.value ?: "" }
-            div { attributes["style"] = "font-size: 13px; color: ${style.secondaryColor.toHexColor()}; margin-bottom: 8px;" ; +flattened }
+            div {
+                attributes["style"] = "font-size: 13px; color: ${style.secondaryColor.toHexColor()}; margin-bottom: 8px;"
+                elements.forEach { renderElement(it, style) }
+            }
         }
         footer.terms?.let { elements ->
             div {
                 attributes["style"] = "font-size: 11px; font-weight: bold; text-transform: uppercase; color: ${style.secondaryColor.toHexColor()}; margin-bottom: 4px;"
                 +"Terms"
             }
-            val flattened = elements.joinToString("") { (it as? InvoiceElement.Text)?.value ?: "" }
-            div { attributes["style"] = "font-size: 12px; color: ${style.secondaryColor.toHexColor()};" ; +flattened }
+            div {
+                attributes["style"] = "font-size: 12px; color: ${style.secondaryColor.toHexColor()};"
+                elements.forEach { renderElement(it, style) }
+            }
         }
         footer.customContent?.let { elements ->
-            val flattened = elements.joinToString("") { (it as? InvoiceElement.Text)?.value ?: "" }
-            div { attributes["style"] = "font-size: 12px; color: ${style.secondaryColor.toHexColor()}; margin-top: 8px;" ; +flattened }
+            div {
+                attributes["style"] = "font-size: 12px; color: ${style.secondaryColor.toHexColor()}; margin-top: 8px;"
+                elements.forEach { renderElement(it, style) }
+            }
         }
         val pb = branding?.takeIf { it.layout == BrandLayout.POWERED_BY_FOOTER }?.poweredBy
         if (pb != null) {

--- a/render-html-email/src/commonMain/kotlin/com/chrisjenx/kinvoicing/html/email/sections/PaymentInfoHtml.kt
+++ b/render-html-email/src/commonMain/kotlin/com/chrisjenx/kinvoicing/html/email/sections/PaymentInfoHtml.kt
@@ -24,14 +24,15 @@ internal fun FlowContent.renderPaymentInfo(payment: InvoiceSection.PaymentInfo, 
             div {
                 attributes["style"] = "margin-top: 8px;"
                 a {
-                    href = requireSafeUrl(link, "paymentLink")
+                    href = requireSafeUrl(link.href, "paymentLink")
                     attributes["style"] = "color: ${style.primaryColor.toHexColor()}; font-size: 14px; font-weight: bold; text-decoration: none;"
-                    +"Pay Online: $link"
+                    +link.text
                 }
             }
         }
-        payment.notes?.let {
-            div { attributes["style"] = "margin-top: 8px; font-size: 12px; color: ${style.secondaryColor.toHexColor()};" ; +it }
+        payment.notes?.let { elements ->
+            val flattened = elements.joinToString("") { (it as? InvoiceElement.Text)?.value ?: "" }
+            div { attributes["style"] = "margin-top: 8px; font-size: 12px; color: ${style.secondaryColor.toHexColor()};" ; +flattened }
         }
     }
 }

--- a/render-html-email/src/commonMain/kotlin/com/chrisjenx/kinvoicing/html/email/sections/PaymentInfoHtml.kt
+++ b/render-html-email/src/commonMain/kotlin/com/chrisjenx/kinvoicing/html/email/sections/PaymentInfoHtml.kt
@@ -1,7 +1,6 @@
 package com.chrisjenx.kinvoicing.html.email.sections
 
 import com.chrisjenx.kinvoicing.*
-import com.chrisjenx.kinvoicing.util.requireSafeUrl
 import kotlinx.html.*
 
 internal fun FlowContent.renderPaymentInfo(payment: InvoiceSection.PaymentInfo, style: InvoiceStyle) {
@@ -23,16 +22,14 @@ internal fun FlowContent.renderPaymentInfo(payment: InvoiceSection.PaymentInfo, 
         payment.paymentLink?.let { link ->
             div {
                 attributes["style"] = "margin-top: 8px;"
-                a {
-                    href = requireSafeUrl(link.href, "paymentLink")
-                    attributes["style"] = "color: ${style.primaryColor.toHexColor()}; font-size: 14px; font-weight: bold; text-decoration: none;"
-                    +link.text
-                }
+                renderElement(link, style)
             }
         }
         payment.notes?.let { elements ->
-            val flattened = elements.joinToString("") { (it as? InvoiceElement.Text)?.value ?: "" }
-            div { attributes["style"] = "margin-top: 8px; font-size: 12px; color: ${style.secondaryColor.toHexColor()};" ; +flattened }
+            div {
+                attributes["style"] = "margin-top: 8px;"
+                elements.forEach { renderElement(it, style) }
+            }
         }
     }
 }

--- a/render-html-email/src/commonTest/kotlin/com/chrisjenx/kinvoicing/html/email/HtmlRendererTest.kt
+++ b/render-html-email/src/commonTest/kotlin/com/chrisjenx/kinvoicing/html/email/HtmlRendererTest.kt
@@ -195,4 +195,45 @@ class HtmlRendererTest {
         assertTrue(html.isNotBlank())
         assertTrue("INV-2026-0001" in html)
     }
+
+    @Test
+    fun customSectionTextLinkRendersAsInlineAnchor() {
+        val doc = invoice {
+            custom("test") { link("Home", "https://example.com") }
+        }
+        val html = doc.toHtml()
+        assertTrue(
+            "href=\"https://example.com\"" in html,
+            "Expected an <a href=\"https://example.com\"> in TEXT-style output",
+        )
+        assertTrue(">Home<" in html, "Expected the link's display text to render")
+        // TEXT-style links live inside a <div>, not a bulletproof <table><td>.
+        val anchorIdx = html.indexOf("href=\"https://example.com\"")
+        val priorTagOpen = html.lastIndexOf("<", anchorIdx)
+        val priorTag = html.substring(priorTagOpen, anchorIdx)
+        assertFalse("<td" in priorTag, "TEXT link should not be wrapped in a <td>")
+    }
+
+    @Test
+    fun customSectionButtonRendersInsideTable() {
+        val doc = invoice {
+            custom("test") { button("Pay Now", "https://pay.example.com") }
+        }
+        val html = doc.toHtml()
+        assertTrue(
+            "href=\"https://pay.example.com\"" in html,
+            "Expected an <a href=\"https://pay.example.com\"> in BUTTON-style output",
+        )
+        assertTrue(">Pay Now<" in html, "Expected the button's label to render")
+        // Bulletproof BUTTON: anchor lives inside <td> within a <table>.
+        val anchorIdx = html.indexOf("href=\"https://pay.example.com\"")
+        val precedingHtml = html.substring(0, anchorIdx)
+        val tableIdx = precedingHtml.lastIndexOf("<table")
+        val tdIdx = precedingHtml.lastIndexOf("<td")
+        assertTrue(tableIdx >= 0 && tdIdx > tableIdx, "BUTTON link should be wrapped in <table><tr><td>")
+        // Confirm M3 visual defaults land on the <td>.
+        val tdAttrs = precedingHtml.substring(tdIdx)
+        assertTrue("border-radius:20px" in tdAttrs, "Expected border-radius:20px on button <td>")
+        assertTrue("padding:10px 24px" in tdAttrs, "Expected padding:10px 24px on button <td>")
+    }
 }

--- a/render-pdf/src/jvmTest/kotlin/com/chrisjenx/kinvoicing/pdf/PdfRendererTest.kt
+++ b/render-pdf/src/jvmTest/kotlin/com/chrisjenx/kinvoicing/pdf/PdfRendererTest.kt
@@ -87,16 +87,6 @@ class PdfRendererTest {
     }
 
     @Test
-    fun paymentLinkAnnotationPresent() {
-        val bytes = renderer.render(InvoiceFixtures.fullFeatured)
-        val text = extractText(bytes)
-        assertTrue(
-            "Pay Now" in text || "Pay Online" in text || "pay.acme.com" in text,
-            "PDF should contain payment link text"
-        )
-    }
-
-    @Test
     fun extensionFunctionWorks() {
         val bytes = InvoiceFixtures.basic.toPdf()
         assertTrue(bytes.isNotEmpty())

--- a/render-pdf/src/jvmTest/kotlin/com/chrisjenx/kinvoicing/pdf/PdfRendererTest.kt
+++ b/render-pdf/src/jvmTest/kotlin/com/chrisjenx/kinvoicing/pdf/PdfRendererTest.kt
@@ -91,7 +91,7 @@ class PdfRendererTest {
         val bytes = renderer.render(InvoiceFixtures.fullFeatured)
         val text = extractText(bytes)
         assertTrue(
-            "pay.acme.com" in text || "Pay Online" in text,
+            "Pay Now" in text || "Pay Online" in text || "pay.acme.com" in text,
             "PDF should contain payment link text"
         )
     }


### PR DESCRIPTION
## Summary

Adds `link()` and `button()` to every block that holds free-text content (Custom sections, `paymentInfo { notes { … } }`, `footer { notes/terms/customContent { … } }`), and lets the PaymentInfo pay link render as a markdown-style inline TEXT link or a styled "Pay Now" CTA button. Both render-pdf and render-html-email keep the link clickable, with Material 3 visual defaults.

The original report ("PDF pay links are not wired up correctly") was incorrect — `LinkAndImageTest` already verified real `PDAnnotationLink` annotations were emitted. The actual problems were that the rendered text was hard-coded `"Pay Online: <url>"` with no choice of presentation, and `link()` was only callable inside `Custom` sections.

## What changed

### Added
- **`LinkStyle` enum** on `InvoiceElement.Link` (`TEXT` default, `BUTTON`).
- **`button(text, href)`** in a new shared `ContentBuilder` DSL — usable wherever rich content is accepted.
- **`paymentLink(text, href, style?)`** overload + **`paymentButton(text, href)`** convenience.
- **Rich `notes`/`terms`/`customContent` lambdas** on PaymentInfo and Footer that accept a `ContentBuilder.() -> Unit` body.
- HTML email BUTTON renders as a bulletproof `<table>` (Outlook-friendly).
- New `payButton` test fixture; new `renderPreviews` Gradle task for visual review.
- Migration guide at `docs/migration/1.2.0-link-button-dsl.md`.

### Changed (breaking — IR only)
- `PaymentInfo.paymentLink: String?` → `InvoiceElement.Link?`
- `PaymentInfo.notes`, `Footer.{notes, terms, customContent}: String?` → `List<InvoiceElement>?`
- `CustomBuilder.row { }` receiver narrowed from `CustomBuilder` to `ContentBuilder`
- Default rendered pay-link text: `"Pay Online: <url>"` → `"Pay Now"` (or your custom label)

DSL string-form setters and single-arg `paymentLink(href)` are unchanged — most user code keeps compiling. Breaking changes hit code that inspects the IR directly (custom renderers, JSON serialisation, tests).

### Removed
- `PdfRendererTest.paymentLinkAnnotationPresent` — misleading text-substring check; superseded by real annotation coverage in `fidelity-test/LinkAndImageTest`.

## Architecture

- **One canonical type:** `InvoiceElement.Link(text, href, style)`.
- **One canonical builder:** `ContentBuilder` — `CustomBuilder` extends it; `PaymentInfoBuilder`/`FooterBuilder` accept `ContentBuilder.() -> Unit` lambdas.
- **One canonical Compose renderer:** `ElementContent` composable with TEXT/BUTTON branch, called by every section.
- **One canonical HTML renderer path:** `renderElement` in `CustomHtml.kt`, called by PaymentInfoHtml and FooterHtml.

PDF clickability is unchanged because `LocalLinkWrapper { PdfLink(href) { content() } }` already wraps any content — the new `Box`-based BUTTON gets a `PDAnnotationLink` over its bounds for free.

## Visual previews

Generated via `./gradlew :kinvoicing-docs:renderPreviews`:

- `payButton` PDF: BUTTON-style "Pay $1,000 Now" CTA, plus inline TEXT links inside payment notes ("transfer policy") and footer notes ("terms", "contact support").
- `payButton` HTML email: same structure, BUTTON wrapped in bulletproof `<table>`.
- `linksAndImages` (existing fixture): default TEXT-style "Pay Now" inline link, "Visit Our Website" inline link.

## Test plan

- [x] `./gradlew :core:jvmTest` — IR + DSL coverage including new overloads
- [x] `./gradlew :render-compose:jvmTest`
- [x] `./gradlew :render-pdf:jvmTest`
- [x] `./gradlew :render-html-email:jvmTest` — includes new TEXT vs BUTTON markup tests
- [x] `./gradlew :fidelity-test:jvmTest` — cross-renderer `LinkAndImageTest` with new BUTTON, embedded notes-link, and footer-link annotation assertions
- [x] `./gradlew :kinvoicing-fidelity-test:test` — compose2pdf visual regressions (BUILD SUCCESSFUL in 42s)
- [x] `./gradlew :kinvoicing-docs:run` and `:renderPreviews` — section previews regenerate and visually confirm new rendering
- [ ] Reviewer: open `payButton.pdf` in a PDF viewer; click the button; confirm it opens the URL

## Notes for reviewer

- The IR breaking changes are documented in `CHANGELOG.md` and `docs/migration/1.2.0-link-button-dsl.md`. The repo doesn't use release-please — CHANGELOG is maintained manually; GitHub Releases are auto-generated by `gh release create --generate-notes` from the conventional-commit-style commit titles in the release workflow.
- Pre-existing white-on-primary button label means a pale custom primary color won't have enough contrast. Flagged in the migration doc as a follow-up to expose `style.onPrimaryColor`.
- `:render-html` (the standalone Compose→HTML pipeline) was intentionally left out — it doesn't depend on `:core` and doesn't render invoices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)