### PR TITLE
ci: use latest-stable Xcode for iOS link (fixes red main + release)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,13 @@ jobs:
           distribution: temurin
           java-version: 17
 
+      # macos-latest default Xcode lacks the UIUtilities framework that
+      # CMP 1.11+ auto-links from compose.ui-uikit (linkDebugTestIosSimulatorArm64
+      # fails on _OBJC_CLASS_$_UIViewLayoutRegion). Match compatibility.yml.
+      - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+        with:
+          xcode-version: latest-stable
+
       - uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d # v4
 
       - name: iOS simulator tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,13 @@ jobs:
           distribution: temurin
           java-version: 17
 
+      # macos-latest default Xcode lacks the UIUtilities framework that
+      # CMP 1.11+ auto-links from compose.ui-uikit (linkDebugTestIosSimulatorArm64
+      # fails on _OBJC_CLASS_$_UIViewLayoutRegion). Match compatibility.yml.
+      - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+        with:
+          xcode-version: latest-stable
+
       - uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d # v4
 
       - name: Build all targets
@@ -78,6 +85,11 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
+
+      # See test job: CMP 1.11+ needs latest-stable Xcode for the UIUtilities framework.
+      - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+        with:
+          xcode-version: latest-stable
 
       - uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d # v4
 


### PR DESCRIPTION
## Why

CMP 1.11+ auto-links the `UIUtilities` framework from `compose.ui-uikit`. The runner's **default Xcode (16.4) lacks it**, so `:render-compose:linkDebugTestIosSimulatorArm64` fails:

```
ld: warning: Could not find or use auto-linked framework 'UIUtilities': framework 'UIUtilities' not found
Undefined symbols: "_OBJC_CLASS_$_UIViewLayoutRegion" ... in ui-uikit-cache.a
> Task :render-compose:linkDebugTestIosSimulatorArm64 FAILED
```

`compatibility.yml` already pins `setup-xcode@latest-stable` for this — so its iOS leg stayed green and **masked the regression**. But when #12 bumped the base CMP to 1.11.1, the two workflows that hand-declare their own runner setup — `build.yml` (`apple-tests`) and `release.yml` (`test`) — were never updated. Result:

- **`main` is red:** the post-#12 `build.yml` run failed on `apple-tests` + `CI Gate` (run 28554234409).
- **The v1.3.0 release failed** at the `test` job (run 28554565384). Nothing published — `publish`/`tag`/`bump` all skipped, so no partial release to unwind.

This is workflow-config drift: three workflows each declare the Xcode step independently, and two drifted. A code test-matrix can't catch it — it validates that the code links under the right Xcode, not that every workflow sets that Xcode up.

## What

Add `setup-xcode@latest-stable` (pinned SHA, matching `compatibility.yml`) to:
- `build.yml` → `apple-tests` (unbreaks `main`)
- `release.yml` → `test` and `publish`

## After merge

Re-trigger `release.yml -f version=1.3.0`.

## Follow-up (not in this PR)

The step is now declared in 3 places. Worth DRYing into a composite action / reusable setup so it can't drift again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)